### PR TITLE
Fix illegal offset type

### DIFF
--- a/Classes/ViewHelpers/LinkedData/ItemViewHelper.php
+++ b/Classes/ViewHelpers/LinkedData/ItemViewHelper.php
@@ -66,7 +66,13 @@ class ItemViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
 		}
 
 		if ($this->arguments['object'] !== NULL) {
-			$container[$this->arguments['subject']][$this->arguments['predicate']][$this->arguments['object']] = NULL;
+			if(is_array($this->arguments['object'])) {
+				foreach ($this->arguments['object'] as $value) {
+					$container[$this->arguments['subject']][$this->arguments['predicate']][$value] = NULL;
+				}
+			} else {
+				$container[$this->arguments['subject']][$this->arguments['predicate']][$this->arguments['object']] = NULL;
+			}
 		}
 		else {
 			$container[$this->arguments['subject']][$this->arguments['predicate']][$this->renderChildren()] = array('type' => $this->arguments['objectType'], 'language' => $this->arguments['language']);


### PR DESCRIPTION
Line 69 of `ItemViewHelper.php` regularly throws a a lot of errors (“PHP Warning: Illegal offset type”) in our logs. The problem is that sometimes `$this->arguments['object']` is an array and not a string. In the example below the value is not a single string of an author but an array of strings for multiple authors.

Being an array it cannot be used as a key for `$container[$this->arguments['subject']][$this->arguments['predicate']]`. Therefore, the PHP Warning.

The backend silently fails and outputs an incomplete (?) .json (but writes the warning into the TYPO3 log) though.

For example (https://katalogbeta.slub-dresden.de/id/0018322184/?type=1369315139&tx_find_find%5Bformat%5D=data&tx_find_find%5Bdata-format%5D=json-ld)

`{"@context":{"so":"http:\/\/schema.org\/"},"@graph":[{"@id":"http:\/\/katalogbeta.slub-dresden.de\/id\/0018322184","so:name":"Dresden \/","so:url":"http:\/\/katalogbeta.slub-dresden.de\/id\/0018322184","@type":"so:Book"}]}`

with this change it outputs all authors instead of none:

`{"@context":{"so":"http:\/\/schema.org\/"},"@graph":[{"@id":"http:\/\/katalogbeta.slub-dresden.de\/id\/0018322184","so:name":"Dresden \/","so:author":["Eisenschmid, Rainer","M\u00fcnch, Christoph","Reincke, Madeleine"],"so:url":"http:\/\/katalogbeta.slub-dresden.de\/id\/0018322184","@type":"so:Book"}]}`

I don’t know if this changed output is valid or if these cases have to be handled differently at the source of this call.
