### PR TITLE
Fix decoding and escaping for facet keys and query terms

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -130,8 +130,23 @@ class SearchController extends ActionController
             $this->addStandardAssignments();
             $defaultQuery = $this->searchProvider->getDefaultQuery();
 
+            // Decode facet keys for display
+            $arguments = $this->searchProvider->getRequestArguments();
+            if (isset($arguments['facet']) && is_array($arguments['facet'])) {
+                foreach ($arguments['facet'] as $facetId => $facetTerms) {
+                    if (is_array($facetTerms)) {
+                        $decodedTerms = [];
+                        foreach ($facetTerms as $term => $value) {
+                            $decodedTerm = urldecode($term);
+                            $decodedTerms[$decodedTerm] = $value;
+                        }
+                        $arguments['facet'][$facetId] = $decodedTerms;
+                    }
+                }
+            }
+
             $viewValues = [
-                'arguments' => $this->searchProvider->getRequestArguments(),
+                'arguments' => $arguments,
                 'config' => $this->searchProvider->getConfiguration(),
             ];
 

--- a/Classes/Service/SolrServiceProvider.php
+++ b/Classes/Service/SolrServiceProvider.php
@@ -520,7 +520,18 @@ class SolrServiceProvider extends AbstractServiceProvider
             }
         }
 
-        return $activeFacetsForTemplate;
+        // Decode facet keys and term values for template display
+        $decodedActiveFacets = [];
+        foreach ($activeFacetsForTemplate as $facetID => $facets) {
+            $decodedActiveFacets[$facetID] = [];
+            foreach ($facets as $facetTerm => $facetInfo) {
+                $decodedTerm = urldecode($facetTerm);
+                $facetInfo['term'] = $decodedTerm;
+                $decodedActiveFacets[$facetID][$decodedTerm] = $facetInfo;
+            }
+        }
+
+        return $decodedActiveFacets;
     }
 
     /**
@@ -1057,6 +1068,8 @@ class SolrServiceProvider extends AbstractServiceProvider
                     $queryPattern = ($facetConfig['field'] ?: $facetConfig['id']).':'.'%s';
                 }
 
+                $queryTerm = urldecode($queryTerm);
+                
                 // Hack: convert strings »RANGE XX TO YY« Solr style range queries »[XX TO YY]«
                 // (because PHP loses ] in array keys during URL parsing)
                 $queryTerm = preg_replace('#RANGE (.*) TO (.*)#', '[\1 TO \2]', $queryTerm);

--- a/Classes/Service/SolrServiceProvider.php
+++ b/Classes/Service/SolrServiceProvider.php
@@ -1069,6 +1069,10 @@ class SolrServiceProvider extends AbstractServiceProvider
                 }
 
                 $queryTerm = urldecode($queryTerm);
+
+                if ($facetConfig['escapeQuotes'] ?? false) {
+                    $queryTerm = str_replace('"', '\\"', $queryTerm);
+                }
                 
                 // Hack: convert strings »RANGE XX TO YY« Solr style range queries »[XX TO YY]«
                 // (because PHP loses ] in array keys during URL parsing)


### PR DESCRIPTION
This pull request introduces improvements to how facet keys and term values are handled in the search functionality, specifically ensuring that they are properly decoded from URL encoding before being displayed or used in queries. This enhances both the user interface and query accuracy by presenting readable facet terms and preventing encoding-related issues.

Facet display and query improvements:

* Decoded facet keys for display in the `indexAction` method of `SearchController.php`, ensuring facet terms shown to users are human-readable.
* Decoded facet keys and term values for template display in the `addFacetFilters` method of `SolrServiceProvider.php`, so templates receive properly formatted facet data.
* Decoded facet query terms in the `getFacetQuery` method of `SolrServiceProvider.php` before building Solr queries, improving query accuracy and consistency.